### PR TITLE
Get the DI tests working

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,11 +51,11 @@ spec:
            defaultValue: 'https://download.eclipse.org/ee4j/jakartaee-tck/8.0.1/nightly/glassfish.zip', 
            description: 'URL required for downloading GlassFish Full/Web profile bundle' )
     string(name: 'JAVAX_INJECT_TCK_URL',
-           defaultValue: 'https://github.com/javax-inject/javax-inject/releases/download/1/javax.inject-tck.zip',
-           description: 'URL required for downloading AT Inject TCK Bundle' )
+           defaultValue: 'http://download.eclipse.org/ee4j/cdi/jakarta.inject-tck-1.0-bin.zip',
+           description: 'URL required for downloading Jakarta DI TCK Bundle' )
     string(name: 'JSR299_TCK_URL', 
-           defaultValue: 'https://sourceforge.net/projects/jboss/files/CDI-TCK/1.0.6.Final/jsr299-tck-1.0.6.Final-dist.zip/download',
-           description: 'URL required for downloading JSR 299 TCK bundle' )
+           defaultValue: 'http://download.eclipse.org/ee4j/cdi/cdi-tck-2.0.6-dist.zip',
+           description: 'URL required for downloading Jakarta CDI TCK bundle' )
     string(name: 'TCK_BUNDLE_BASE_URL',
            defaultValue: '',
            description: 'Base URL required for downloading prebuilt binary TCK Bundle from a hosted location' )

--- a/build.xml
+++ b/build.xml
@@ -56,6 +56,7 @@
 	<target name="downloadDependencies">
 		<get src="http://central.maven.org/maven2/junit/junit/4.12/junit-4.12.jar" verbose="on" dest="lib"/>
 		<get src="http://central.maven.org/maven2/org/slf4j/slf4j-simple/1.7.25/slf4j-simple-1.7.25.jar" verbose="on" dest="lib"/>
+		<get src="https://repo1.maven.org/maven2/org/jboss/arquillian/container/arquillian-weld-embedded/2.0.1.Final/arquillian-weld-embedded-2.0.1.Final.jar" verbose="on" dest="lib"/>
 	</target>
 	<target name="print-classpath">
 

--- a/build.xml
+++ b/build.xml
@@ -27,8 +27,8 @@
 	<property name="dist" value="${basedir}/dist" />
 	<property name="lib" value="${basedir}/lib" />
 	<property name="dist.file" value="330-tck-glassfish-porting" />
-	<property name="slf4j.jar" value="${porting.home}/lib/slf4j-simple-1.7.25.jar" />
-	<property name="junit.jar" value="${porting.home}/lib/junit-4.12.jar" />
+	<property name="slf4j.jar" value="${porting.home}/slf4j-simple-1.7.25.jar" />
+	<property name="junit.jar" value="${porting.home}/junit-4.12.jar" />
 
 	<taskdef resource="net/sf/antcontrib/antlib.xml" classpath="${lib}/ant-contrib.jar" />
 
@@ -47,7 +47,7 @@
 		<fileset dir="${tck.home}">
 			<include name="javax.inject-tck.jar" />
 		</fileset>
-		<fileset dir="${porting.home}/lib">
+		<fileset dir="${porting.home}">
 			<include name="weld-inject-tck-runner-tests.jar" />
 		</fileset>
                 <pathelement location="${slf4j.jar}"/>

--- a/build.xml
+++ b/build.xml
@@ -56,7 +56,7 @@
 	<target name="downloadDependencies">
 		<get src="http://central.maven.org/maven2/junit/junit/4.12/junit-4.12.jar" verbose="on" dest="lib"/>
 		<get src="http://central.maven.org/maven2/org/slf4j/slf4j-simple/1.7.25/slf4j-simple-1.7.25.jar" verbose="on" dest="lib"/>
-		<get src="https://repo1.maven.org/maven2/org/jboss/arquillian/container/arquillian-weld-embedded/2.0.1.Final/arquillian-weld-embedded-2.0.1.Final.jar" verbose="on" dest="lib"/>
+		<get src="https://repo1.maven.org/maven2/org/jboss/arquillian/container/arquillian-weld-embedded/2.0.1.Final/arquillian-weld-embedded-2.0.1.Final.jar" verbose="on" dest="${porting.home}"/>
 	</target>
 	<target name="print-classpath">
 

--- a/build.xml
+++ b/build.xml
@@ -48,7 +48,7 @@
 			<include name="javax.inject-tck.jar" />
 		</fileset>
 		<fileset dir="${porting.home}/lib">
-			<include name="weld-inject-tck-runner-1.0.0-tests.jar" />
+			<include name="weld-inject-tck-runner-tests.jar" />
 		</fileset>
                 <pathelement location="${slf4j.jar}"/>
 	</path>

--- a/build.xml
+++ b/build.xml
@@ -57,7 +57,12 @@
 		<get src="http://central.maven.org/maven2/junit/junit/4.12/junit-4.12.jar" verbose="on" dest="lib"/>
 		<get src="http://central.maven.org/maven2/org/slf4j/slf4j-simple/1.7.25/slf4j-simple-1.7.25.jar" verbose="on" dest="lib"/>
 	</target>
-	<target name="run" depends="downloadDependencies">
+	<target name="print-classpath">
+
+		<pathconvert property="classpathValue" refid="classpath" />
+		<echo>Classpath is ${classpathValue}</echo>
+	</target>
+	<target name="run" depends="downloadDependencies,print-classpath">
 		<mkdir dir="${report.dir}"/>
                 <junit>
 			<classpath>

--- a/docker/build_ditck.sh
+++ b/docker/build_ditck.sh
@@ -37,8 +37,7 @@ ant -version
  
 which mvn
 mvn -version
- 
- 
+
 sed -i "s#^porting\.home=.*#porting.home=$WORKSPACE#g" "$WORKSPACE/build.xml"
 sed -i "s#^glassfish\.home=.*#glassfish.home=$WORKSPACE/glassfish5/glassfish#g" "$WORKSPACE/build.xml"
  

--- a/docker/run_ditck.sh
+++ b/docker/run_ditck.sh
@@ -40,10 +40,10 @@ ant -version
 REPORT=${WORKSPACE}/330tck-report
 mkdir -p ${REPORT}
 if [ -z "${JAVAX_INJECT_TCK_URL}" ];then
-  JAVAX_INJECT_TCK_URL=https://github.com/javax-inject/javax-inject/releases/download/1/javax.inject-tck.zip
+  JAVAX_INJECT_TCK_URL=http://download.eclipse.org/ee4j/cdi/jakarta.inject-tck-1.0-bin.zip
 fi
 if [ -z "${JSR299_TCK_URL}" ];then
-  JSR299_TCK_URL=https://sourceforge.net/projects/jboss/files/CDI-TCK/1.0.6.Final/jsr299-tck-1.0.6.Final-dist.zip/download
+  JSR299_TCK_URL=http://download.eclipse.org/ee4j/cdi/cdi-tck-2.0.6-dist.zip
 fi
 
 wget ${JAVAX_INJECT_TCK_URL} -O ${WORKSPACE}/javax.inject-tck.zip 
@@ -51,11 +51,15 @@ wget ${JSR299_TCK_URL} -O ${WORKSPACE}/jsr299-tck.zip
 unzip ${WORKSPACE}/javax.inject-tck.zip  -d ${WORKSPACE}
 unzip ${WORKSPACE}/jsr299-tck.zip -d ${WORKSPACE}
 
+# Install the porting lib
+cd ${WORKSPACE}/cdi-tck-2.0.6/weld/porting-package-lib
+mvn install
+
 #Edit test properties
 sed -i "s#ts.home=.*#ts.home=${WORKSPACE}#g" ${TS_HOME}/build.properties
 sed -i "s#porting.home=.*#porting.home=${TS_HOME}#g" ${TS_HOME}/build.properties
 sed -i "s#glassfish.home=.*#glassfish.home=${WORKSPACE}/glassfish5/glassfish#g" ${TS_HOME}/build.properties
-sed -i "s#299.tck.home=.*#299.tck.home=${WORKSPACE}/jsr299-tck-1.0.6.Final#g" ${TS_HOME}/build.properties
+sed -i "s#299.tck.home=.*#299.tck.home=${WORKSPACE}/cdi-tck-2.0.6#g" ${TS_HOME}/build.properties
 sed -i "s#report.dir=.*#report.dir=${REPORT}#g" ${TS_HOME}/build.properties
 
 #Run Tests

--- a/docker/run_ditck.sh
+++ b/docker/run_ditck.sh
@@ -54,16 +54,21 @@ unzip ${WORKSPACE}/jsr299-tck.zip -d ${WORKSPACE}
 # Install the porting lib
 cd ${WORKSPACE}/cdi-tck-2.0.6/weld/porting-package-lib
 mvn install
+echo "+++ Installed CDI TCK porting libs"
+ls target/dependency
+cd ${WORKSPACE}
 
 #Edit test properties
 sed -i "s#ts.home=.*#ts.home=${WORKSPACE}#g" ${TS_HOME}/build.properties
-sed -i "s#porting.home=.*#porting.home=${TS_HOME}#g" ${TS_HOME}/build.properties
+sed -i "s#porting.home=.*#porting.home=${WORKSPACE}/cdi-tck-2.0.6/weld/porting-package-lib/target/dependency#g" ${TS_HOME}/build.properties
 sed -i "s#glassfish.home=.*#glassfish.home=${WORKSPACE}/glassfish5/glassfish#g" ${TS_HOME}/build.properties
 sed -i "s#299.tck.home=.*#299.tck.home=${WORKSPACE}/cdi-tck-2.0.6#g" ${TS_HOME}/build.properties
 sed -i "s#report.dir=.*#report.dir=${REPORT}#g" ${TS_HOME}/build.properties
 
 #Run Tests
 cd ${TS_HOME}
+echo "+++ Ant build.properties:"
+cat build.properties
 ant run
 
 #Generate Reports


### PR DESCRIPTION
With these changes I am able to run the org.jboss.weld.atinject.tck.AtInjectTCK tests

```
run:
    [junit] Testsuite: org.jboss.weld.atinject.tck.AtInjectTCK
    [junit] Tests run: 50, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.298 sec
    [junit] ------------- Standard Error -----------------
    [junit] Aug 20, 2019 6:35:59 AM org.jboss.weld.bootstrap.WeldStartup <clinit>
    [junit] INFO: WELD-000900: 3.0.0 (Final)
    [junit] Aug 20, 2019 6:35:59 AM org.hibernate.validator.internal.util.Version <clinit>
    [junit] INFO: HV000001: Hibernate Validator 6.0.10.Final
    [junit] Aug 20, 2019 6:36:00 AM org.jboss.weld.bootstrap.WeldStartup startContainer
    [junit] INFO: WELD-000101: Transactional services not available. Injection of @Inject UserTransaction not available. Transactional observers will be invoked synchronously.
    [junit] Aug 20, 2019 6:36:00 AM org.jboss.weld.event.ExtensionObserverMethodImpl checkRequiredTypeAnnotations
    [junit] INFO: WELD-000411: Observer method [BackedAnnotatedMethod] public org.glassfish.jms.injection.JMSCDIExtension.processAnnotatedType(@Observes ProcessAnnotatedType<T>) receives events for all annotated types. Consider restricting events using @WithAnnotations or a generic type with bounds.
    [junit] Aug 20, 2019 6:36:00 AM org.jboss.weld.event.ExtensionObserverMethodImpl checkRequiredTypeAnnotations
    [junit] INFO: WELD-000411: Observer method [BackedAnnotatedMethod] org.glassfish.sse.impl.ServerSentEventCdiExtension.processAnnotatedType(@Observes ProcessAnnotatedType<T>, BeanManager) receives events for all annotated types. Consider restricting events using @WithAnnotations or a generic type with bounds.
    [junit] Aug 20, 2019 6:36:00 AM org.jboss.weld.event.ExtensionObserverMethodImpl checkRequiredTypeAnnotations
    [junit] INFO: WELD-000411: Observer method [BackedAnnotatedMethod] private org.glassfish.jersey.ext.cdi1x.internal.CdiComponentProvider.processAnnotatedType(@Observes ProcessAnnotatedType) receives events for all annotated types. Consider restricting events using @WithAnnotations or a generic type with bounds.
    [junit] Aug 20, 2019 6:36:00 AM org.jboss.weld.event.ExtensionObserverMethodImpl checkRequiredTypeAnnotations
    [junit] INFO: WELD-000411: Observer method [BackedAnnotatedMethod] public org.hibernate.validator.cdi.ValidationExtension.processAnnotatedType(@Observes ProcessAnnotatedType<T>) receives events for all annotated types. Consider restricting events using @WithAnnotations or a generic type with bounds.
    [junit] Aug 20, 2019 6:36:01 AM org.jboss.weld.bootstrap.events.BeforeBeanDiscoveryImpl addAnnotatedType
    [junit] WARN: WELD-000146: BeforeBeanDiscovery.addAnnotatedType(AnnotatedType<?>) used for class org.glassfish.jersey.ext.cdi1x.internal.CdiComponentProvider$JaxRsParamProducer is deprecated from CDI 1.1!
    [junit] Aug 20, 2019 6:36:01 AM org.jboss.weld.bootstrap.events.BeforeBeanDiscoveryImpl addAnnotatedType
    [junit] WARN: WELD-000146: BeforeBeanDiscovery.addAnnotatedType(AnnotatedType<?>) used for class org.glassfish.jersey.ext.cdi1x.servlet.internal.CdiExternalRequestScope is deprecated from CDI 1.1!
    [junit] Aug 20, 2019 6:36:01 AM org.jboss.weld.bootstrap.events.BeforeBeanDiscoveryImpl addAnnotatedType
    [junit] WARN: WELD-000146: BeforeBeanDiscovery.addAnnotatedType(AnnotatedType<?>) used for class com.ibm.jbatch.container.cdi.BatchProducerBean is deprecated from CDI 1.1!
    [junit] Aug 20, 2019 6:36:01 AM org.jboss.weld.bootstrap.events.BeforeBeanDiscoveryImpl addAnnotatedType
    [junit] WARN: WELD-000146: BeforeBeanDiscovery.addAnnotatedType(AnnotatedType<?>) used for class org.glassfish.cdi.transaction.TransactionalInterceptorMandatory is deprecated from CDI 1.1!
    [junit] Aug 20, 2019 6:36:01 AM org.jboss.weld.bootstrap.events.BeforeBeanDiscoveryImpl addAnnotatedType
    [junit] WARN: WELD-000146: BeforeBeanDiscovery.addAnnotatedType(AnnotatedType<?>) used for class org.glassfish.cdi.transaction.TransactionalInterceptorNever is deprecated from CDI 1.1!
    [junit] Aug 20, 2019 6:36:01 AM org.jboss.weld.bootstrap.events.BeforeBeanDiscoveryImpl addAnnotatedType
    [junit] WARN: WELD-000146: BeforeBeanDiscovery.addAnnotatedType(AnnotatedType<?>) used for class org.glassfish.cdi.transaction.TransactionalInterceptorNotSupported is deprecated from CDI 1.1!
    [junit] Aug 20, 2019 6:36:01 AM org.jboss.weld.bootstrap.events.BeforeBeanDiscoveryImpl addAnnotatedType
    [junit] WARN: WELD-000146: BeforeBeanDiscovery.addAnnotatedType(AnnotatedType<?>) used for class org.glassfish.cdi.transaction.TransactionalInterceptorRequired is deprecated from CDI 1.1!
    [junit] Aug 20, 2019 6:36:01 AM org.jboss.weld.bootstrap.events.BeforeBeanDiscoveryImpl addAnnotatedType
    [junit] WARN: WELD-000146: BeforeBeanDiscovery.addAnnotatedType(AnnotatedType<?>) used for class org.glassfish.cdi.transaction.TransactionalInterceptorRequiresNew is deprecated from CDI 1.1!
    [junit] Aug 20, 2019 6:36:01 AM org.jboss.weld.bootstrap.events.BeforeBeanDiscoveryImpl addAnnotatedType
    [junit] WARN: WELD-000146: BeforeBeanDiscovery.addAnnotatedType(AnnotatedType<?>) used for class org.glassfish.cdi.transaction.TransactionalInterceptorSupports is deprecated from CDI 1.1!
    [junit] Aug 20, 2019 6:36:01 AM org.jboss.weld.bootstrap.events.BeforeBeanDiscoveryImpl addAnnotatedType
    [junit] WARN: WELD-000146: BeforeBeanDiscovery.addAnnotatedType(AnnotatedType<?>) used for class org.glassfish.jersey.ext.cdi1x.transaction.internal.WebAppExceptionHolder is deprecated from CDI 1.1!
    [junit] Aug 20, 2019 6:36:01 AM org.jboss.weld.bootstrap.events.BeforeBeanDiscoveryImpl addAnnotatedType
    [junit] WARN: WELD-000146: BeforeBeanDiscovery.addAnnotatedType(AnnotatedType<?>) used for class org.glassfish.jersey.ext.cdi1x.transaction.internal.WebAppExceptionInterceptor is deprecated from CDI 1.1!
    [junit] Aug 20, 2019 6:36:01 AM org.jboss.weld.bootstrap.events.BeforeBeanDiscoveryImpl addAnnotatedType
    [junit] WARN: WELD-000146: BeforeBeanDiscovery.addAnnotatedType(AnnotatedType<?>) used for class org.glassfish.jersey.ext.cdi1x.transaction.internal.TransactionalExceptionMapper is deprecated from CDI 1.1!
    [junit] Aug 20, 2019 6:36:01 AM org.jboss.weld.bootstrap.events.BeforeBeanDiscoveryImpl addAnnotatedType
    [junit] WARN: WELD-000146: BeforeBeanDiscovery.addAnnotatedType(AnnotatedType<?>) used for class com.sun.faces.flow.FlowDiscoveryCDIHelper is deprecated from CDI 1.1!
    [junit] ------------- ---------------- ---------------
    [junit] 
    [junit] Testcase: testSupertypeFieldsInjected took 0.001 sec
    [junit] Testcase: testSupertypeMethodsInjected took 0 sec
    [junit] Testcase: testTwiceOverriddenMethodInjectedWhenMiddleLacksAnnotation took 0 sec
    [junit] Testcase: testQualifiersNotInheritedFromOverriddenMethod took 0 sec
    [junit] Testcase: testConstructorInjectionWithValues took 0 sec
    [junit] Testcase: testMethodWithZeroParametersInjected took 0 sec
    [junit] Testcase: testFieldInjectionWithValues took 0 sec
    [junit] Testcase: testMethodInjectionWithValues took 0 sec
    [junit] Testcase: testConstructorInjectionWithProviders took 0.001 sec
    [junit] Testcase: testFieldInjectionWithProviders took 0 sec
    [junit] Testcase: testMethodInjectionWithProviders took 0 sec
    [junit] Testcase: testConstructorInjectedProviderYieldsSingleton took 0.001 sec
    [junit] Testcase: testFieldInjectedProviderYieldsSingleton took 0 sec
    [junit] Testcase: testMethodInjectedProviderYieldsSingleton took 0 sec
    [junit] Testcase: testCircularlyDependentSingletons took 0 sec
    [junit] Testcase: testSingletonAnnotationNotInheritedFromSupertype took 0 sec
    [junit] Testcase: testConstructorInjectedProviderYieldsDistinctValues took 0.002 sec
    [junit] Testcase: testFieldInjectedProviderYieldsDistinctValues took 0 sec
    [junit] Testcase: testMethodInjectedProviderYieldsDistinctValues took 0.001 sec
    [junit] Testcase: testPackagePrivateMethodInjectedDifferentPackages took 0 sec
    [junit] Testcase: testOverriddenProtectedMethodInjection took 0 sec
    [junit] Testcase: testOverriddenPublicMethodNotInjected took 0 sec
    [junit] Testcase: testFieldsInjectedBeforeMethods took 0 sec
    [junit] Testcase: testSupertypeMethodsInjectedBeforeSubtypeFields took 0 sec
    [junit] Testcase: testSupertypeMethodInjectedBeforeSubtypeMethods took 0 sec
    [junit] Testcase: testPackagePrivateMethodInjectedEvenWhenSimilarMethodLacksAnnotation took 0 sec
    [junit] Testcase: testPrivateMethodNotInjectedWhenSupertypeHasAnnotatedSimilarMethod took 0 sec
    [junit] Testcase: testPackagePrivateMethodNotInjectedWhenOverrideLacksAnnotation took 0 sec
    [junit] Testcase: testPackagePrivateMethodNotInjectedWhenSupertypeHasAnnotatedSimilarMethod took 0 sec
    [junit] Testcase: testProtectedMethodNotInjectedWhenOverrideNotAnnotated took 0 sec
    [junit] Testcase: testPublicMethodNotInjectedWhenOverrideNotAnnotated took 0 sec
    [junit] Testcase: testTwiceOverriddenMethodNotInjectedWhenOverrideLacksAnnotation took 0 sec
    [junit] Testcase: testOverriddingMixedWithPackagePrivate2 took 0 sec
    [junit] Testcase: testOverriddingMixedWithPackagePrivate3 took 0 sec
    [junit] Testcase: testOverriddingMixedWithPackagePrivate4 took 0 sec
    [junit] Testcase: testOverriddenPackagePrivateMethodInjectedOnlyOnce took 0 sec
    [junit] Testcase: testSimilarPackagePrivateMethodInjectedOnlyOnce took 0 sec
    [junit] Testcase: testOverriddenProtectedMethodInjectedOnlyOnce took 0 sec
    [junit] Testcase: testOverriddenPublicMethodInjectedOnlyOnce took 0 sec
    [junit] Testcase: testNonVoidMethodInjected took 0 sec
    [junit] Testcase: testMethodWithMultipleParametersInjected took 0 sec
    [junit] Testcase: testPublicNoArgsConstructorInjected took 0 sec
    [junit] Testcase: testSubtypeFieldsInjected took 0 sec
    [junit] Testcase: testSubtypeMethodsInjected took 0 sec
    [junit] Testcase: testProviderReturnedValues took 0 sec
    [junit] Testcase: testFieldsInjected took 0 sec
    [junit] Testcase: testPrivateMethodInjectedEvenWhenSimilarMethodLacksAnnotation took 0 sec
    [junit] Testcase: testSupertypePrivateMethodInjected took 0 sec
    [junit] Testcase: testPackagePrivateMethodInjectedSamePackage took 0 sec
    [junit] Testcase: testSimilarPrivateMethodInjectedOnlyOnce took 0 sec
report:
[junitreport] Processing /home/jenkins/workspace/GlassfishTCKRun/330tck-report/TESTS-TestSuites.xml to /tmp/null685580293
[junitreport] Loading stylesheet jar:file:/usr/share/ant/lib/ant-junit.jar!/org/apache/tools/ant/taskdefs/optional/junit/xsl/junit-frames.xsl
[junitreport] Transform time: 507ms
[junitreport] Deleting: /tmp/null685580293
     [echo] Report written to /home/jenkins/workspace/GlassfishTCKRun/330tck-report
```
