### PR TITLE
update inject, arquillian-weld-embedded, cdi-tck

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,19 +48,25 @@ spec:
   }
   parameters {
     string(name: 'GF_BUNDLE_URL', 
-           defaultValue: 'https://download.eclipse.org/ee4j/jakartaee-tck/8.0.1/nightly/glassfish.zip', 
+           defaultValue: 'https://ci.eclipse.org/jakartaee-tck/job/build-glassfish/lastSuccessfulBuild/artifact/appserver/distributions/glassfish/target/glassfish.zip', 
            description: 'URL required for downloading GlassFish Full/Web profile bundle' )
-    string(name: 'JAVAX_INJECT_TCK_URL',
-           defaultValue: 'http://download.eclipse.org/ee4j/cdi/jakarta.inject-tck-1.0-bin.zip',
+    string(name: 'JAKARTA_INJECT_TCK_URL',
+           defaultValue: 'https://download.eclipse.org/ee4j/cdi/jakarta.inject-tck-2.0.0-RC4-bin.zip',
            description: 'URL required for downloading Jakarta DI TCK Bundle' )
+    string(name: 'JAKARTA_INJECT_VERSION',
+           defaultValue: '2.0.0-RC4',
+           description: 'Jakarta DI TCK VERSION' )
     string(name: 'JSR299_TCK_URL', 
-           defaultValue: 'http://download.eclipse.org/ee4j/cdi/cdi-tck-2.0.6-dist.zip',
+           defaultValue: 'https://download.eclipse.org/ee4j/cdi/cdi-tck-3.0.0-M3-dist.zip',
            description: 'URL required for downloading Jakarta CDI TCK bundle' )
+    string(name: 'JSR299_TCK_VERSION', 
+           defaultValue: '3.0.0-M3',
+           description: 'CDI TCK version' )
     string(name: 'TCK_BUNDLE_BASE_URL',
            defaultValue: '',
            description: 'Base URL required for downloading prebuilt binary TCK Bundle from a hosted location' )
     string(name: 'TCK_BUNDLE_FILE_NAME', 
-           defaultValue: '330-tck-glassfish-porting-1.0.0.zip', 
+           defaultValue: '330-tck-glassfish-porting-2.0.0.zip', 
 	   description: 'Name of bundle file to be appended to the base url' )
   }
 

--- a/build.xml
+++ b/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,7 +21,7 @@
 
 	<property file="${basedir}/build.properties" />
 
-	<property name="tck.version" value="1.0.0"/>
+	<property name="tck.version" value="2.0.0"/>
 	<property name="src" value="${basedir}/src" />
 	<property name="classes" value="${basedir}/classes" />
 	<property name="dist" value="${basedir}/dist" />
@@ -42,10 +42,10 @@
 			<include name="lib/*.jar" />
 		</fileset>
 		<fileset dir="${299.tck.home}">
-                        <include name="**/*.jar" /> <exclude name="**/javax.inject*.jar"/>
+                        <include name="**/*.jar" /> <exclude name="**/jakarta.inject*.jar"/>
 		</fileset>
 		<fileset dir="${tck.home}">
-                        <include name="jakarta.inject-tck-1.0.jar" />
+                        <include name="jakarta.inject-tck-*.jar" />
 		</fileset>
 		<fileset dir="${porting.home}">
                         <include name="**/*.jar" />
@@ -54,12 +54,11 @@
 	</path>
     <!--Proxy information should be provided in ANT_OPTS env variable as set ANT_OPTS=-Dhttp.proxyHost=host -Dhttp.proxyPort=port-->
 	<target name="downloadDependencies">
-		<get src="http://central.maven.org/maven2/junit/junit/4.12/junit-4.12.jar" verbose="on" dest="lib"/>
-		<get src="http://central.maven.org/maven2/org/slf4j/slf4j-simple/1.7.25/slf4j-simple-1.7.25.jar" verbose="on" dest="lib"/>
-		<get src="https://repo1.maven.org/maven2/org/jboss/arquillian/container/arquillian-weld-embedded/2.0.1.Final/arquillian-weld-embedded-2.0.1.Final.jar" verbose="on" dest="${porting.home}"/>
+		<get src="https://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar" verbose="on" dest="lib"/>
+		<get src="https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/1.7.25/slf4j-simple-1.7.25.jar" verbose="on" dest="lib"/>
+		<get src="https://repo1.maven.org/maven2/org/jboss/arquillian/container/arquillian-weld-embedded/3.0.0.Alpha1/arquillian-weld-embedded-3.0.0.Alpha1.jar" verbose="on" dest="${porting.home}"/>
 	</target>
 	<target name="print-classpath">
-
 		<pathconvert property="classpathValue" refid="classpath" />
 		<echo>Classpath is ${classpathValue}</echo>
 	</target>

--- a/docker/build_ditck.sh
+++ b/docker/build_ditck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 #
-# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -39,7 +39,7 @@ which mvn
 mvn -version
 
 sed -i "s#^porting\.home=.*#porting.home=$WORKSPACE#g" "$WORKSPACE/build.xml"
-sed -i "s#^glassfish\.home=.*#glassfish.home=$WORKSPACE/glassfish5/glassfish#g" "$WORKSPACE/build.xml"
+sed -i "s#^glassfish\.home=.*#glassfish.home=$WORKSPACE/glassfish6/glassfish#g" "$WORKSPACE/build.xml"
  
 ant -version
 ant dist.sani

--- a/docker/run_ditck.sh
+++ b/docker/run_ditck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 #
-# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 
-VER="1.0"
+VER="2.0"
 
 if ls ${WORKSPACE}/bundles/*330-tck-glassfish-porting-*.zip 1> /dev/null 2>&1; then
   unzip -o ${WORKSPACE}/bundles/*330-tck-glassfish-porting-*.zip -d ${WORKSPACE}
@@ -27,9 +27,9 @@ fi
 export TS_HOME=${WORKSPACE}/330-tck-glassfish-porting
 
 #Install Glassfish
-echo "Download and install GlassFish 5.0.1 ..."
+echo "Download and install GlassFish 6 ..."
 if [ -z "${GF_BUNDLE_URL}" ]; then
-  export GF_BUNDLE_URL="http://download.oracle.com/glassfish/5.0.1/nightly/latest-glassfish.zip"
+  export GF_BUNDLE_URL="https://ci.eclipse.org/jakartaee-tck/job/build-glassfish/lastSuccessfulBuild/artifact/appserver/distributions/glassfish/target/glassfish.zip"
 fi
 wget --progress=bar:force --no-cache $GF_BUNDLE_URL -O latest-glassfish.zip
 unzip -o ${WORKSPACE}/latest-glassfish.zip -d ${WORKSPACE}
@@ -39,30 +39,38 @@ ant -version
 
 REPORT=${WORKSPACE}/330tck-report
 mkdir -p ${REPORT}
-if [ -z "${JAVAX_INJECT_TCK_URL}" ];then
-  JAVAX_INJECT_TCK_URL=http://download.eclipse.org/ee4j/cdi/jakarta.inject-tck-1.0-bin.zip
+if [ -z "${JAKARTA_INJECT_TCK_URL}" ];then
+  JAKARTA_INJECT_TCK_URL=https://download.eclipse.org/ee4j/cdi/jakarta.inject-tck-2.0.0-bin.zip
 fi
 if [ -z "${JSR299_TCK_URL}" ];then
-  JSR299_TCK_URL=http://download.eclipse.org/ee4j/cdi/cdi-tck-2.0.6-dist.zip
+  JSR299_TCK_URL=https://download.eclipse.org/ee4j/cdi/cdi-tck-3.0.0-dist.zip
 fi
 
-wget ${JAVAX_INJECT_TCK_URL} -O ${WORKSPACE}/javax.inject-tck.zip 
+if [ -z "${JAKARTA_INJECT_VERSION}" ]; then
+  JAKARTA_INJECT_VERSION="2.0.0"
+fi
+
+if [ -z "${JSR299_TCK_VERSION}" ]; then
+  JSR299_TCK_VERSION="3.0.0"
+fi
+
+wget ${JAKARTA_INJECT_TCK_URL} -O ${WORKSPACE}/jakarta.inject-tck.zip 
 wget ${JSR299_TCK_URL} -O ${WORKSPACE}/jsr299-tck.zip
-unzip ${WORKSPACE}/javax.inject-tck.zip  -d ${WORKSPACE}
+unzip ${WORKSPACE}/jakarta.inject-tck.zip  -d ${WORKSPACE}
 unzip ${WORKSPACE}/jsr299-tck.zip -d ${WORKSPACE}
 
 # Install the porting lib
-cd ${WORKSPACE}/cdi-tck-2.0.6/weld/porting-package-lib
+cd ${WORKSPACE}/cdi-tck-${JSR299_TCK_VERSION}/weld/porting-package-lib
 mvn install
 echo "+++ Installed CDI TCK porting libs"
 ls target/dependency
 cd ${WORKSPACE}
 
 #Edit test properties
-sed -i "s#tck.home=.*#tck.home=${WORKSPACE}/jakarta.inject-tck-1.0#g" ${TS_HOME}/build.properties
+sed -i "s#tck.home=.*#tck.home=${WORKSPACE}/jakarta.inject-tck-${JAKARTA_INJECT_VERSION}#g" ${TS_HOME}/build.properties
 sed -i "s#porting.home=.*#porting.home=${TS_HOME}#g" ${TS_HOME}/build.properties
-sed -i "s#glassfish.home=.*#glassfish.home=${WORKSPACE}/glassfish5/glassfish#g" ${TS_HOME}/build.properties
-sed -i "s#299.tck.home=.*#299.tck.home=${WORKSPACE}/cdi-tck-2.0.6#g" ${TS_HOME}/build.properties
+sed -i "s#glassfish.home=.*#glassfish.home=${WORKSPACE}/glassfish6/glassfish#g" ${TS_HOME}/build.properties
+sed -i "s#299.tck.home=.*#299.tck.home=${WORKSPACE}/cdi-tck-${JSR299_TCK_VERSION}#g" ${TS_HOME}/build.properties
 sed -i "s#report.dir=.*#report.dir=${REPORT}#g" ${TS_HOME}/build.properties
 
 #Run Tests


### PR DESCRIPTION
Signed-off-by: Gurunandan <gurunandan.rao@oracle.com>
DI porting TCK upgrade to use inject 3.0.0 and glassfish 6.
CI run - https://ci.eclipse.org/jakartaee-tck/job/ditck-porting-grao/job/master/lastBuild/