### PR TITLE
revert cdi tck to M3, since RC1 is not available in maven central repo.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,10 +57,10 @@ spec:
            defaultValue: '2.0.1',
            description: 'Jakarta DI TCK VERSION' )
     string(name: 'JSR299_TCK_URL', 
-           defaultValue: 'https://jakarta.oss.sonatype.org/content/repositories/staging/jakarta/enterprise/cdi-tck-dist/3.0.0-RC1/cdi-tck-dist-3.0.0-RC1-dist.zip',
+           defaultValue: 'https://download.eclipse.org/ee4j/cdi/cdi-tck-3.0.0-M3-dist.zip',
            description: 'URL required for downloading Jakarta CDI TCK bundle' )
     string(name: 'JSR299_TCK_VERSION', 
-           defaultValue: '3.0.0-RC1',
+           defaultValue: '3.0.0-M3',
            description: 'CDI TCK version' )
     string(name: 'TCK_BUNDLE_BASE_URL',
            defaultValue: '',


### PR DESCRIPTION
Signed-off-by: Gurunandan <gurunandan.rao@oracle.com>