### PR TITLE
Update to use the tck runner source in the inject tck dist

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -21,14 +21,14 @@
 
 	<property file="${basedir}/build.properties" />
 
-	<property name="tck.version" value="2.0.1"/>
+	<property name="tck.version" value="2.0.2"/>
 	<property name="src" value="${basedir}/src" />
 	<property name="classes" value="${basedir}/classes" />
 	<property name="dist" value="${basedir}/dist" />
 	<property name="lib" value="${basedir}/lib" />
 	<property name="dist.file" value="330-tck-glassfish-porting" />
-	<property name="slf4j.jar" value="${porting.home}/lib/slf4j-simple-1.7.25.jar" />
-	<property name="junit.jar" value="${porting.home}/lib/junit-4.12.jar" />
+	<property name="slf4j.jar" value="${lib}/slf4j-simple-1.7.25.jar" />
+	<property name="junit.jar" value="${lib}/junit-4.12.jar" />
 
 	<taskdef resource="net/sf/antcontrib/antlib.xml" classpath="${lib}/ant-contrib.jar" />
 
@@ -41,41 +41,58 @@
 		<fileset dir="${glassfish.home}">
 			<include name="lib/*.jar" />
 		</fileset>
-		<fileset dir="${299.tck.home}">
-                        <include name="**/*.jar" /> <exclude name="**/jakarta.inject*.jar"/>
-		</fileset>
-		<fileset dir="${tck.home}">
-                        <include name="jakarta.inject-tck-*.jar" />
-		</fileset>
 		<fileset dir="${porting.home}">
-                        <include name="**/*.jar" />
+      <include name="**/*.jar" />
 		</fileset>
-                <pathelement location="${slf4j.jar}"/>
+		<pathelement location="${slf4j.jar}"/>
 	</path>
     <!--Proxy information should be provided in ANT_OPTS env variable as set ANT_OPTS=-Dhttp.proxyHost=host -Dhttp.proxyPort=port-->
 	<target name="downloadDependencies">
 		<get src="https://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar" verbose="on" dest="lib"/>
 		<get src="https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/1.7.25/slf4j-simple-1.7.25.jar" verbose="on" dest="lib"/>
-		<get src="https://repo1.maven.org/maven2/org/jboss/arquillian/container/arquillian-weld-embedded/3.0.0.Alpha1/arquillian-weld-embedded-3.0.0.Alpha1.jar" verbose="on" dest="${porting.home}"/>
+		<get src="https://repo1.maven.org/maven2/org/jboss/weld/se/weld-se-core/5.0.0.SP2/weld-se-core-5.0.0.SP2.jar" verbose="on" dest="${porting.home}"/>
 	</target>
 	<target name="print-classpath">
 		<pathconvert property="classpathValue" refid="classpath" />
 		<echo>Classpath is ${classpathValue}</echo>
+		<echo>299.tck.home is ${299.tck.home}</echo>
+		<echo>tck.home is ${tck.home}</echo>
 	</target>
-	<target name="run" depends="downloadDependencies,print-classpath">
+	<target name="compile-runner">
+		<mkdir dir="${classes}" />
+		<unjar dest="${classes}" src="${299.tck.home}/jakarta.inject-tck-${tck.version}.jar">
+			<patternset>
+				<exclude name="META-INF/**" />
+			</patternset>
+		</unjar>
+		<javac srcdir="${299.tck.home}/example/src/test/java"
+					 classpathref="classpath"
+					 classpath="${classes}"
+					 destdir="${classes}"
+		/>
+		<copy todir="${classes}">
+			<fileset dir="${299.tck.home}/example/src/test/resources">
+				<patternset>
+					<include name="META-INF/**" />
+				</patternset>
+			</fileset>
+		</copy>
+	</target>
+	<target name="run" depends="downloadDependencies,print-classpath,compile-runner">
 		<mkdir dir="${report.dir}"/>
-                <junit>
+		<junit>
 			<classpath>
+				<pathelement location="${classes}" />
 				<path refid="classpath"/>
 			</classpath>
 			<formatter type="xml"/>
 			<formatter type="plain" usefile="false" />
                         <!-- Uncomment this sys prop to workaround this Glassfish 3.1 Jersey bug - https://glassfish.dev.java.net/issues/show_bug.cgi?id=13131 -->
-                        <sysproperty key="com.sun.jersey.server.impl.cdi.lookupExtensionInBeanManager" value="true"/>
-			<test name="org.jboss.weld.atinject.tck.AtInjectTCK"
-                              todir="${report.dir}"/>
+                       <sysproperty key="com.sun.jersey.server.impl.cdi.lookupExtensionInBeanManager" value="true"/>
+			<test name="weld.SampleBootstrapTCK"
+			  todir="${report.dir}"/>
 		</junit>
-                <antcall target="report"/>
+		<antcall target="report"/>
 	</target>
 
         <target name="report">


### PR DESCRIPTION
Signed-off-by: Scott M Stark <starksm64@gmail.com>

With these changes I get the following output from ant run:

```
└> ant run  
...
compile-runner:
    [mkdir] Created dir: /Users/starksm/Dev/JBoss/Jakarta/rh-ditck-porting/classes
    [unjar] Expanding: /tmp/jakarta.inject-tck-2.0.2/jakarta.inject-tck-2.0.2.jar into /Users/starksm/Dev/JBoss/Jakarta/rh-ditck-porting/classes
    [javac] /Users/starksm/Dev/JBoss/Jakarta/rh-ditck-porting/build.xml:72: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
    [javac] Compiling 2 source files to /Users/starksm/Dev/JBoss/Jakarta/rh-ditck-porting/classes
    [javac] warning: Supported source version 'RELEASE_7' from annotation processor 'org.netbeans.modules.schema2beansdev.Schema2BeansProcessor' less than -source '11'
    [javac] Note: /tmp/jakarta.inject-tck-2.0.2/example/src/test/java/weld/SampleBootstrapTCK.java uses unchecked or unsafe operations.
    [javac] Note: Recompile with -Xlint:unchecked for details.
    [javac] 1 warning
     [copy] Copying 1 file to /Users/starksm/Dev/JBoss/Jakarta/rh-ditck-porting/classes

run:
    [junit] Testsuite: weld.SampleBootstrapTCK
    [junit] Tests run: 50, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.035 sec
    [junit] ------------- Standard Output ---------------
    [junit] Added @Drivers to: [BackedAnnotatedType] public  class org.atinject.tck.auto.DriversSeat
    [junit] Added @Spare to [BackedAnnotatedField] @Inject org.atinject.tck.auto.Convertible.spareTire
    [junit] Added @Named('spare') to: [BackedAnnotatedType] public  class org.atinject.tck.auto.accessories.SpareTire
    [junit] ------------- ---------------- ---------------
    [junit] ------------- Standard Error -----------------
    [junit] Jun 15, 2022 9:17:36 PM org.jboss.weld.bootstrap.WeldStartup <clinit>
    [junit] INFO: WELD-000900: 5.0.0 (SP2)
    [junit] Jun 15, 2022 9:17:36 PM org.hibernate.validator.internal.util.Version <clinit>
    [junit] INFO: HV000001: Hibernate Validator 8.0.0.Alpha3
    [junit] Jun 15, 2022 9:17:37 PM org.jboss.weld.util.ServiceLoader loadClass
    [junit] WARNING: Could not load service class io.helidon.microprofile.config.ConfigCdiExtension
    [junit] Jun 15, 2022 9:17:37 PM org.jboss.weld.environment.deployment.discovery.ReflectionDiscoveryStrategy processAnnotatedDiscovery
    [junit] INFO: WELD-ENV-000014: Falling back to Java Reflection for bean-discovery-mode="annotated" discovery. Add org.jboss:jandex to the classpath to speed-up startup.
    [junit] Jun 15, 2022 9:17:37 PM org.jboss.weld.bootstrap.WeldStartup startContainer
    [junit] INFO: WELD-000101: Transactional services not available. Injection of @Inject UserTransaction not available. Transactional observers will be invoked synchronously.
    [junit] Jun 15, 2022 9:17:37 PM org.jboss.weld.event.ExtensionObserverMethodImpl checkRequiredTypeAnnotations
    [junit] INFO: WELD-000411: Observer method [BackedAnnotatedMethod] public org.glassfish.jms.injection.JMSCDIExtension.processAnnotatedType(@Observes ProcessAnnotatedType<T>) receives events for all annotated types. Consider restricting events using @WithAnnotations or a generic type with bounds.
    [junit] Jun 15, 2022 9:17:37 PM org.jboss.weld.event.ExtensionObserverMethodImpl checkRequiredTypeAnnotations
    [junit] INFO: WELD-000411: Observer method [BackedAnnotatedMethod] org.glassfish.sse.impl.ServerSentEventCdiExtension.processAnnotatedType(@Observes ProcessAnnotatedType<T>, BeanManager) receives events for all annotated types. Consider restricting events using @WithAnnotations or a generic type with bounds.
    [junit] Jun 15, 2022 9:17:37 PM org.jboss.weld.event.ExtensionObserverMethodImpl checkRequiredTypeAnnotations
    [junit] INFO: WELD-000411: Observer method [BackedAnnotatedMethod] public org.glassfish.jersey.ext.cdi1x.internal.ProcessAllAnnotatedTypes.processAnnotatedType(@Observes ProcessAnnotatedType<?>, BeanManager) receives events for all annotated types. Consider restricting events using @WithAnnotations or a generic type with bounds.
    [junit] Jun 15, 2022 9:17:38 PM org.jboss.weld.environment.se.WeldContainer fireContainerInitializedEvent
    [junit] INFO: WELD-ENV-002003: Weld SE container 22bb312c-8c25-4556-9fd6-16d73e785376 initialized
    [junit] ------------- ---------------- ---------------
    [junit] 
    [junit] Testcase: testOverriddenPublicMethodInjectedOnlyOnce took 0.003 sec
    [junit] Testcase: testPackagePrivateMethodNotInjectedWhenOverrideLacksAnnotation took 0 sec
    [junit] Testcase: testProviderReturnedValues took 0 sec
    [junit] Testcase: testQualifiersNotInheritedFromOverriddenMethod took 0 sec
    [junit] Testcase: testPublicNoArgsConstructorInjected took 0 sec
    [junit] Testcase: testCircularlyDependentSingletons took 0 sec
    [junit] Testcase: testPublicMethodNotInjectedWhenOverrideNotAnnotated took 0 sec
    [junit] Testcase: testPackagePrivateMethodInjectedDifferentPackages took 0 sec
    [junit] Testcase: testSupertypeMethodInjectedBeforeSubtypeMethods took 0 sec
    [junit] Testcase: testFieldInjectedProviderYieldsSingleton took 0 sec
    [junit] Testcase: testConstructorInjectedProviderYieldsSingleton took 0 sec
    [junit] Testcase: testPackagePrivateMethodInjectedEvenWhenSimilarMethodLacksAnnotation took 0 sec
    [junit] Testcase: testOverriddenPackagePrivateMethodInjectedOnlyOnce took 0 sec
    [junit] Testcase: testNonVoidMethodInjected took 0 sec
    [junit] Testcase: testOverriddenPublicMethodNotInjected took 0 sec
    [junit] Testcase: testMethodInjectedProviderYieldsDistinctValues took 0.001 sec
    [junit] Testcase: testProtectedMethodNotInjectedWhenOverrideNotAnnotated took 0 sec
    [junit] Testcase: testSimilarPackagePrivateMethodInjectedOnlyOnce took 0 sec
    [junit] Testcase: testConstructorInjectedProviderYieldsDistinctValues took 0.001 sec
    [junit] Testcase: testOverriddingMixedWithPackagePrivate2 took 0 sec
    [junit] Testcase: testOverriddingMixedWithPackagePrivate3 took 0 sec
    [junit] Testcase: testOverriddingMixedWithPackagePrivate4 took 0 sec
    [junit] Testcase: testMethodInjectionWithProviders took 0.002 sec
    [junit] Testcase: testFieldsInjectedBeforeMethods took 0.001 sec
    [junit] Testcase: testMethodWithZeroParametersInjected took 0 sec
    [junit] Testcase: testOverriddenProtectedMethodInjectedOnlyOnce took 0 sec
    [junit] Testcase: testSubtypeFieldsInjected took 0 sec
    [junit] Testcase: testSupertypeFieldsInjected took 0 sec
    [junit] Testcase: testConstructorInjectionWithValues took 0 sec
    [junit] Testcase: testSingletonAnnotationNotInheritedFromSupertype took 0 sec
    [junit] Testcase: testConstructorInjectionWithProviders took 0.001 sec
    [junit] Testcase: testFieldInjectedProviderYieldsDistinctValues took 0 sec
    [junit] Testcase: testPackagePrivateMethodNotInjectedWhenSupertypeHasAnnotatedSimilarMethod took 0 sec
    [junit] Testcase: testSubtypeMethodsInjected took 0.001 sec
    [junit] Testcase: testTwiceOverriddenMethodInjectedWhenMiddleLacksAnnotation took 0 sec
    [junit] Testcase: testPrivateMethodNotInjectedWhenSupertypeHasAnnotatedSimilarMethod took 0 sec
    [junit] Testcase: testTwiceOverriddenMethodNotInjectedWhenOverrideLacksAnnotation took 0 sec
    [junit] Testcase: testFieldInjectionWithValues took 0 sec
    [junit] Testcase: testMethodInjectedProviderYieldsSingleton took 0 sec
    [junit] Testcase: testOverriddenProtectedMethodInjection took 0 sec
    [junit] Testcase: testMethodInjectionWithValues took 0 sec
    [junit] Testcase: testSupertypeMethodsInjectedBeforeSubtypeFields took 0 sec
    [junit] Testcase: testSupertypeMethodsInjected took 0 sec
    [junit] Testcase: testMethodWithMultipleParametersInjected took 0 sec
    [junit] Testcase: testFieldInjectionWithProviders took 0.001 sec
    [junit] Testcase: testFieldsInjected took 0 sec
    [junit] Testcase: testSupertypePrivateMethodInjected took 0 sec
    [junit] Testcase: testPrivateMethodInjectedEvenWhenSimilarMethodLacksAnnotation took 0 sec
    [junit] Testcase: testPackagePrivateMethodInjectedSamePackage took 0 sec
    [junit] Testcase: testSimilarPrivateMethodInjectedOnlyOnce took 0 sec

report:
[junitreport] the file /tmp/output/TESTS-TestSuites.xml is not a valid testsuite XML document
[junitreport] Processing /tmp/output/TESTS-TestSuites.xml to /var/folders/kv/ff1f9vc10n3bgm8x63knvy9w0000gn/T/null816169152
[junitreport] Loading stylesheet jar:file:/usr/local/Cellar/ant/1.10.12/libexec/lib/ant-junit.jar!/org/apache/tools/ant/taskdefs/optional/junit/xsl/junit-frames.xsl
[junitreport] Transform time: 530ms
[junitreport] Deleting: /var/folders/kv/ff1f9vc10n3bgm8x63knvy9w0000gn/T/null816169152
     [echo] Report written to /tmp/output

BUILD SUCCESSFUL
Total time: 10 seconds
Weld SE container 22bb312c-8c25-4556-9fd6-16d73e785376 shut down by shutdown hook
```

